### PR TITLE
Fix Vite mixed-content issues

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,22 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
+import fs from 'fs';
 
 export default defineConfig({
     server: {
-        host: '0.0.0.0', // 👈 expose Vite outside container
-        port: 5173,      // 👈 lock to 5173 so Laravel knows where to find it
-        strictPort: true // 👈 fail if taken — better for dev/debug
+        host: 'yardageiq.local',
+        port: 5173,
+        strictPort: true,
+        https: {
+            key: fs.readFileSync('certs/yardageiq.local-key.pem'),
+            cert: fs.readFileSync('certs/yardageiq.local.pem'),
+        },
+        hmr: {
+            host: 'yardageiq.local',
+            protocol: 'wss',
+            port: 5173,
+        },
     },
     plugins: [
         laravel({


### PR DESCRIPTION
## Summary
- use HTTPS for Vite dev server
- point dev server to `yardageiq.local`
- configure HMR to use the same host
- read TLS certs from `certs/` directory

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854d27329f4833081686aaba1f794ae