### PR TITLE
Configure Vite dev server for HTTPS

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,10 +14,19 @@ export default defineConfig({
     ],
     server: {
         https: {
-            key: fs.readFileSync(path.resolve(__dirname, 'bootstrap/nginx/key.pem')),
-            cert: fs.readFileSync(path.resolve(__dirname, 'bootstrap/nginx/cert.pem')),
+            key: fs.readFileSync(
+                path.resolve(__dirname, 'certs/yardageiq.local-key.pem'),
+            ),
+            cert: fs.readFileSync(
+                path.resolve(__dirname, 'certs/yardageiq.local.pem'),
+            ),
         },
         host: 'yardageiq.local',
         port: 5173,
+        hmr: {
+            protocol: 'wss',
+            host: 'yardageiq.local',
+            port: 5173,
+        },
     },
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server to serve over HTTPS with certificates
- set dev server host to `yardageiq.local`
- configure HMR to connect using `wss://yardageiq.local:5173`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d326700c8330ae99e8574177f918