### PR TITLE
Apply custom Tailwind palette to layout

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,30 +1,31 @@
 @extends('layouts.app')
 
 @section('content')
-    <div class="max-w-4xl mx-auto">
-        <h2 class="text-3xl font-extrabold mb-8 text-center text-green-700">Club Stats Overview</h2>
+    <h2 class="text-3xl font-extrabold mb-6 text-center text-primary">Club Stats Overview</h2>
+    <div class="text-right mb-4">
+        <a href="#" class="inline-block px-4 py-2 bg-turf text-white rounded hover:bg-green-500">Add Stat</a>
+    </div>
 
-        <div class="bg-white shadow overflow-hidden rounded-lg">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-green-100">
+    <div class="overflow-hidden rounded-lg">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-coolgray">
                 <tr>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-green-800 uppercase tracking-wider">Club</th>
-                    <th class="px-6 py-3 text-center text-xs font-medium text-green-800 uppercase tracking-wider">Pro</th>
-                    <th class="px-6 py-3 text-center text-xs font-medium text-green-800 uppercase tracking-wider">Amateur</th>
-                    <th class="px-6 py-3 text-center text-xs font-medium text-green-800 uppercase tracking-wider">Regular</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-slate uppercase tracking-wider">Club</th>
+                    <th class="px-6 py-3 text-center text-xs font-medium text-slate uppercase tracking-wider">Pro</th>
+                    <th class="px-6 py-3 text-center text-xs font-medium text-slate uppercase tracking-wider">Amateur</th>
+                    <th class="px-6 py-3 text-center text-xs font-medium text-slate uppercase tracking-wider">Regular</th>
                 </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                @foreach ($stats as $row)
-                    <tr class="hover:bg-green-50 transition">
-                        <td class="px-6 py-4 font-medium text-gray-900">{{ $row['club'] }}</td>
-                        <td class="px-6 py-4 text-center">{{ $row['pro']['launch'] }}°</td>
-                        <td class="px-6 py-4 text-center">{{ $row['amateur']['launch'] }}°</td>
-                        <td class="px-6 py-4 text-center">{{ $row['regular']['launch'] }}°</td>
-                    </tr>
-                @endforeach
-                </tbody>
-            </table>
-        </div>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+            @foreach ($stats as $row)
+                <tr class="hover:bg-softblue transition">
+                    <td class="px-6 py-4 font-medium text-gray-900">{{ $row['club'] }}</td>
+                    <td class="px-6 py-4 text-center">{{ $row['pro']['launch'] }}°</td>
+                    <td class="px-6 py-4 text-center">{{ $row['amateur']['launch'] }}°</td>
+                    <td class="px-6 py-4 text-center">{{ $row['regular']['launch'] }}°</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
     </div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,9 +5,9 @@
     <title>YardageIQ</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans">
+<body class="bg-softblue text-slate font-sans min-h-screen">
 
-<header class="bg-green-600 text-white shadow">
+<header class="bg-primary text-white shadow">
     <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
         <h1 class="text-xl font-bold tracking-wide">YardageIQ</h1>
         <nav>
@@ -16,8 +16,12 @@
     </div>
 </header>
 
-<main class="py-10 px-4 sm:px-6 lg:px-8">
-    @yield('content')
+<main class="py-10">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="bg-white p-6 rounded-lg shadow">
+            @yield('content')
+        </div>
+    </div>
 </main>
 
 <footer class="text-sm text-center text-gray-500 py-6">


### PR DESCRIPTION
## Summary
- restyle layout header and background with custom color palette
- wrap content in a centered card container
- refine dashboard table header and row hover colors
- add a green call-to-action button

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d9b010708330ba6dec3afbfa68d6