### PR TITLE
Fix tailwind postcss config and ignore hot file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bootstrap/nginx/key.pem
 ###> symfony/webpack-encore-bundle ###
 /node_modules/
 /public/build/
+/public/hot
 npm-debug.log
 yarn-error.log
 ###< symfony/webpack-encore-bundle ###

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-import tailwindcss from 'tailwindcss';
+import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
 export default {

--- a/public/hot
+++ b/public/hot
@@ -1,1 +1,0 @@
-https://yardageiq.local


### PR DESCRIPTION
## Summary
- import Tailwind PostCSS plugin from `@tailwindcss/postcss`
- ignore `public/hot` and remove tracked file

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854dd3184d88330afb6806d0d58303f