### PR TITLE
Fix dev host and tailwind plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,6 @@
-import tailwindcss from '@tailwindcss/postcss';
+// Use Tailwind's official PostCSS plugin so custom colors are compiled
+// correctly when building assets.
+import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default {

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,9 @@ export default defineConfig({
             key: fs.readFileSync(path.resolve(__dirname, 'bootstrap/nginx/key.pem')),
             cert: fs.readFileSync(path.resolve(__dirname, 'bootstrap/nginx/cert.pem')),
         },
-        host: '0.0.0.0',
+        // Bind directly to the development URL to ensure the correct address
+        // is written to the `.hot` file used by Laravel's asset helper.
+        host: 'yardageiq.local',
         port: 5173,
         strictPort: true,
         origin: 'https://yardageiq.local', // Match exactly your browser URL


### PR DESCRIPTION
## Summary
- ensure Vite dev server writes the correct host to `.hot`
- use official Tailwind CSS PostCSS plugin

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e1e997408330a38e42485f60ea9b