### PR TITLE
Add CI and coverage badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,9 @@ jobs:
         run: docker compose run --rm node npm ci --no-audit --prefer-offline
       - name: Run Node build
         run: docker compose run --rm node npm run build
-      - name: Run PHPUnit
-        run: docker compose run --rm php php artisan test
+      - name: Run PHPUnit with coverage
+        run: docker compose run --rm php php artisan test --coverage-clover=coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # YardageIQ
 
+[![CI](https://github.com/jason-leibe/yardageiq/actions/workflows/tests.yml/badge.svg)](https://github.com/jason-leibe/yardageiq/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/jason-leibe/yardageiq/branch/main/graph/badge.svg)](https://codecov.io/gh/jason-leibe/yardageiq)
+
 YardageIQ is a small Laravel demo that displays golf club statistics. The project
 uses Vite to compile SCSS and JavaScript and ships with a Docker based
 development environment.


### PR DESCRIPTION
## Summary
- show GitHub Actions and code coverage badges in README
- upload PHPUnit coverage to Codecov

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685587ba1f748330b2d586581c716a94