### PR TITLE
Fix coverage metrics extraction

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,8 +41,8 @@ jobs:
 
           METRICS=$(grep -oP '<metrics[^>]+' coverage.xml | tail -n1)
 
-          TOTAL=$(echo "$METRICS" | grep -oP 'statements="\K\d+"')
-          COVERED=$(echo "$METRICS" | grep -oP 'coveredstatements="\K\d+"')
+          TOTAL=$(echo "$METRICS" | grep -oP 'statements="\K\d+')
+          COVERED=$(echo "$METRICS" | grep -oP 'coveredstatements="\K\d+')
 
           echo "Raw metrics: $METRICS"
           echo "Extracted:"


### PR DESCRIPTION
## Summary
- tweak regex in coverage workflow to properly capture coverage metrics

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685592726e0c8330bd17db2fba61b5a0