### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -60,7 +60,7 @@ body {
 }
 
 .table-container {
-  overflow: hidden;
+  overflow-x: auto;
   border-radius: 0.5rem;
 }
 
@@ -174,4 +174,11 @@ body {
     .nav-links a {
         border-radius: 0.375rem;
     }
+}
+
+@media (max-width: 640px) {
+  .stats-table th,
+  .stats-table td {
+    white-space: nowrap;
+  }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>YardageIQ</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     @vite(['resources/css/app.scss', 'resources/js/app.js'])


### PR DESCRIPTION
## Summary
- add viewport meta tag to layout
- allow horizontal scrolling for tables on small screens
- prevent table cells from wrapping on small screens

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855d46853c88330b518d18efb34d4e7